### PR TITLE
Allow passing default value when retrieving attribute - resolves #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ $yourModel->extra_attributes = [
 // retrieving values using dot notation
 $yourModel->extra_attributes->get('rey.side'); // returns 'light'
 
+// retrieve default value when attribute is not exists
+$yourModel->extra_attributes->get('non_existing', 'default'); // returns 'default'
+
 // it has a scope to retrieve all models with the given schemaless attributes
 $yourModel->withSchemalessAttributes(['name' => 'value', 'name2' => 'value2'])->get();
 ```
@@ -148,6 +151,12 @@ $yourModel->extra_attributes = [
 $yourModel->extra_attributes->set('rey.side', 'dark');
 
 $yourModel->extra_attributes->get('rey.side'); // Returns 'dark
+```
+
+You can also pass a default value to the `get` method.
+
+```php
+$yourModel->extra_attributes->get('non_existing', 'default'); // Returns 'default'
 ```
 
 ### Persisting schemaless attributes

--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -37,9 +37,9 @@ class SchemalessAttributes implements ArrayAccess, Countable
         return $this->get($name);
     }
 
-    public function get(string $name)
+    public function get(string $name, $default = null)
     {
-        return array_get($this->schemalessAttributes, $name);
+        return array_get($this->schemalessAttributes, $name, $default);
     }
 
     public function __set(string $name, $value)

--- a/tests/HasSchemalessAttributesTest.php
+++ b/tests/HasSchemalessAttributesTest.php
@@ -23,6 +23,12 @@ class HasSchemalessAttributesTest extends TestCase
     }
 
     /** @test */
+    public function default_value_can_be_passed_when_getting_a_non_existing_schemaless_attribute()
+    {
+        $this->assertEquals('default', $this->testModel->schemaless_attributes->get('non_existing', 'default'));
+    }
+
+    /** @test */
     public function an_schemaless_attribute_can_be_set()
     {
         $this->testModel->schemaless_attributes->name = 'value';


### PR DESCRIPTION
A default value can now be passed as follows.

```php
$yourModel->extra_attributes->get('non_existing', 'default'); // returns 'default'
```