### PR TITLE
Add return to schemalessAttributes macro

### DIFF
--- a/src/SchemalessAttributesServiceProvider.php
+++ b/src/SchemalessAttributesServiceProvider.php
@@ -10,7 +10,7 @@ class SchemalessAttributesServiceProvider extends ServiceProvider
     public function register()
     {
         Blueprint::macro('schemalessAttributes', function (string $columnName = 'schemaless_attributes') {
-            $this->json($columnName)->nullable();
+            return $this->json($columnName)->nullable();
         });
     }
 }


### PR DESCRIPTION
this **PR** will allows to **chain methods** , for example :- 

```php
Schema::table('your_models', function (Blueprint $table) {
    $table->schemalessAttributes('extra_attributes')->after('some_column');
});
```