### PR TITLE
Adds Illuminate's Arrayable contract for compatability with other Laravel packages.

### DIFF
--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -6,8 +6,9 @@ use Countable;
 use ArrayAccess;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Contracts\Support\Arrayable;
 
-class SchemalessAttributes implements ArrayAccess, Countable
+class SchemalessAttributes implements ArrayAccess, Countable, Arrayable
 {
     /** @var \Illuminate\Database\Eloquent\Model */
     protected $model;
@@ -94,6 +95,11 @@ class SchemalessAttributes implements ArrayAccess, Countable
     public function count()
     {
         return count($this->schemalessAttributes);
+    }
+
+    public function toArray(): array
+    {
+        return $this->all();
     }
 
     public static function scopeWithSchemalessAttributes(string $attributeName): Builder

--- a/tests/HasSchemalessAttributesTest.php
+++ b/tests/HasSchemalessAttributesTest.php
@@ -171,6 +171,17 @@ class HasSchemalessAttributesTest extends TestCase
     }
 
     /** @test */
+    public function it_can_be_used_as_an_arrayable()
+    {
+        $this->testModel->schemaless_attributes->name = 'value';
+
+        $this->assertEquals(
+            $this->testModel->schemaless_attributes->toArray(),
+            $this->testModel->schemaless_attributes->all()
+        );
+    }
+
+    /** @test */
     public function it_can_add_and_save_schemaless_attributes_in_one_go()
     {
         $array = [


### PR DESCRIPTION
In order to play nice with the Laravel ecosystem, more precisely with other packages, it would help if the `SchemalessAttributes` class was also `Arrayable`.

I'd much rather this flexibility than having to Transform my object (solves: https://github.com/yajra/laravel-datatables/blob/8.0/src/Utilities/Helper.php#L158)