### PR TITLE
Adds support for wildcards when using get & set methods

### DIFF
--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -40,7 +40,7 @@ class SchemalessAttributes implements ArrayAccess, Countable, Arrayable
 
     public function get(string $name, $default = null)
     {
-        return array_get($this->schemalessAttributes, $name, $default);
+        return data_get($this->schemalessAttributes, $name, $default);
     }
 
     public function __set(string $name, $value)
@@ -50,7 +50,7 @@ class SchemalessAttributes implements ArrayAccess, Countable, Arrayable
 
     public function set(string $name, $value)
     {
-        array_set($this->schemalessAttributes, $name, $value);
+        data_set($this->schemalessAttributes, $name, $value);
 
         $this->model->{$this->sourceAttributeName} = $this->schemalessAttributes;
     }

--- a/tests/HasSchemalessAttributesTest.php
+++ b/tests/HasSchemalessAttributesTest.php
@@ -88,6 +88,32 @@ class HasSchemalessAttributesTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_values_using_wildcards_notation()
+    {
+        $this->testModel->schemaless_attributes->rey = ['sides' => [
+            ['name' => 'light'],
+            ['name' => 'neutral'],
+            ['name' => 'dark']
+        ]];
+
+        $this->assertEquals(['light', 'neutral', 'dark'], $this->testModel->schemaless_attributes->get('rey.sides.*.name'));
+    }
+
+    /** @test */
+    public function it_can_set_values_using_wildcard_notation()
+    {
+        $this->testModel->schemaless_attributes->rey = ['sides' => [
+            ['name' => 'light'],
+            ['name' => 'neutral'],
+            ['name' => 'dark']
+        ]];
+
+        $this->testModel->schemaless_attributes->set('rey.sides.*.name', 'dark');
+
+        $this->assertEquals(['dark', 'dark', 'dark'], $this->testModel->schemaless_attributes->get('rey.sides.*.name'));
+    }
+
+    /** @test */
     public function it_can_set_all_schemaless_attributes_at_once()
     {
         $array = [


### PR DESCRIPTION
I think it is cool to be able to use sintax like 
`$model->schemaless_attributes->get('taks.*.description')`
or
`$model->schemaless_attributes->set('taks.*.status', 'completed')`

^^ think about it
