### PR TITLE
Allow associative array setter for schemaless-attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,17 @@ $yourModel->extra_attributes = [
    'snoke' => ['side' => 'dark']
 ];
 
-// setting/updating multiple values in one go
+// setting/updating multiple values in one go via setMany()
 // (will not overwrite 'rey' set in previous example)
 $yourModel->extra_attributes->setMany([
-   'hahn' => ['side' => 'light'],
+   'han' => ['side' => 'light'],
+   'snoke' => ['side' => 'dark']
+]);
+
+// setting/updating multiple values in one go via set()
+// this will defer to setMany if an iterable passed
+$yourModel->extra_attributes->set([
+   'han' => ['side' => 'light'],
    'snoke' => ['side' => 'dark']
 ]);
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ $yourModel->extra_attributes = [
    'snoke' => ['side' => 'dark']
 ];
 
+// setting/updating multiple values in one go
+// (will not overwrite 'rey' set in previous example)
+$yourModel->extra_attributes->setMany([
+   'hahn' => ['side' => 'light'],
+   'snoke' => ['side' => 'dark']
+]);
+
 // retrieving values using dot notation
 $yourModel->extra_attributes->get('rey.side'); // returns 'light'
 

--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -48,14 +48,20 @@ class SchemalessAttributes implements ArrayAccess, Countable, Arrayable
         $this->set($name, $value);
     }
 
-    public function set(string $name, $value)
+    public function set($attribute, $value = null)
     {
-        data_set($this->schemalessAttributes, $name, $value);
+        if (is_iterable($attribute)) {
+            $this->setMany($attribute);
+
+            return;
+        }
+
+        data_set($this->schemalessAttributes, $attribute, $value);
 
         $this->model->{$this->sourceAttributeName} = $this->schemalessAttributes;
     }
 
-    public function setMany($attributes = [])
+    public function setMany(iterable $attributes = [])
     {
         array_map(function ($key, $item) {
             $this->set($key, $item);

--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -55,6 +55,13 @@ class SchemalessAttributes implements ArrayAccess, Countable, Arrayable
         $this->model->{$this->sourceAttributeName} = $this->schemalessAttributes;
     }
 
+    public function setMany($attributes = [])
+    {
+        array_map(function ($key, $item) {
+            $this->set($key, $item);
+        }, array_keys($attributes), $attributes);
+    }
+
     public function has(string $name): bool
     {
         return array_has($this->schemalessAttributes, $name);

--- a/tests/HasSchemalessAttributesTest.php
+++ b/tests/HasSchemalessAttributesTest.php
@@ -311,6 +311,23 @@ class HasSchemalessAttributesTest extends TestCase
         $this->assertEquals('subVal1', $this->testModel->schemaless_attributes->arr['subKey1']);
     }
 
+    /** @test */
+    public function if_an_iterable_is_passed_to_set_it_will_defer_to_setMany()
+    {
+        $this->testModel->schemaless_attributes->set([
+            'foo' => 'bar',
+            'baz' => 'buzz',
+            'arr' => [
+                'subKey1' => 'subVal1',
+                'subKey2' => 'subVal2',
+            ],
+        ]);
+
+        $this->assertEquals('bar', $this->testModel->schemaless_attributes->foo);
+        $this->assertCount(2, $this->testModel->schemaless_attributes->arr);
+        $this->assertEquals('subVal1', $this->testModel->schemaless_attributes->arr['subKey1']);
+    }
+
     protected function assertContainsModels(array $expectedModels, Collection $actualModels)
     {
         $assertionFailedMessage = 'Expected '.count($expectedModels).' models. Got '.$actualModels->count().' models';

--- a/tests/HasSchemalessAttributesTest.php
+++ b/tests/HasSchemalessAttributesTest.php
@@ -294,6 +294,23 @@ class HasSchemalessAttributesTest extends TestCase
         }
     }
 
+    /** @test */
+    public function it_can_setMany_attributes_at_once_by_passing_an_array_argument()
+    {
+        $this->testModel->schemaless_attributes->setMany([
+            'foo' => 'bar',
+            'baz' => 'buzz',
+            'arr' => [
+                'subKey1' => 'subVal1',
+                'subKey2' => 'subVal2',
+            ],
+        ]);
+
+        $this->assertEquals('bar', $this->testModel->schemaless_attributes->foo);
+        $this->assertCount(2, $this->testModel->schemaless_attributes->arr);
+        $this->assertEquals('subVal1', $this->testModel->schemaless_attributes->arr['subKey1']);
+    }
+
     protected function assertContainsModels(array $expectedModels, Collection $actualModels)
     {
         $assertionFailedMessage = 'Expected '.count($expectedModels).' models. Got '.$actualModels->count().' models';


### PR DESCRIPTION
Open Issue https://github.com/spatie/laravel-schemaless-attributes/issues/36

**Feature Request: ** Allow multiple fields to be set/update at once via associative array parameter in setter.

**Solution: ** Rather than update the set method and added complexity, create a setMany method that accepts an associative array. (opinion) Setting multiple fields should be explicit to avoid unexpected errors.