### PR TITLE
extend collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs
 vendor
 coverage
 .env
+/.phpunit.result.cache

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,8 +20,8 @@
         </whitelist>
     </filter>
     <php>
-        <env name="DB_USERNAME" value="root"/>
-        <env name="DB_PASSWORD" value=""/>
+        <env name="DB_USERNAME" value="username"/>
+        <env name="DB_PASSWORD" value="password"/>
         <env name="DB_DATABASE" value="laravel_schemaless_attributes"/>
         <env name="DB_CONNECTION" value="mysql"/>
     </php>

--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -2,16 +2,16 @@
 
 namespace Spatie\SchemalessAttributes;
 
-use ArrayAccess;
 use Countable;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
+use ArrayAccess;
+use JsonSerializable;
+use IteratorAggregate;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
-use IteratorAggregate;
-use JsonSerializable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
 
 /**
  * @mixin Collection
@@ -83,7 +83,7 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
      */
     public function set($key, $value = null)
     {
-        if(is_iterable($key)) {
+        if (is_iterable($key)) {
             return $this->override($this->collection->merge($key));
         }
 

--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -3,9 +3,9 @@
 namespace Spatie\SchemalessAttributes;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Collection;
 
 class SchemalessAttributes extends Collection
 {
@@ -41,7 +41,7 @@ class SchemalessAttributes extends Collection
 
     public function set($key, $value = null)
     {
-        if(is_iterable($key)) {
+        if (is_iterable($key)) {
             return $this->merge($key);
         }
 

--- a/tests/HasSchemalessAttributesTest.php
+++ b/tests/HasSchemalessAttributesTest.php
@@ -356,14 +356,14 @@ class HasSchemalessAttributesTest extends TestCase
     public function it_can_call_collection_method_sum()
     {
         $this->testModel->schemaless_attributes->set([
-            [ 'price' => 10 ],
-            [ 'price' => 5 ],
+            ['price' => 10],
+            ['price' => 5],
         ]);
 
         $this->assertEquals(15, $this->testModel->schemaless_attributes->sum('price'));
         $this->assertEquals([
-            [ 'price' => 10 ],
-            [ 'price' => 5 ],
+            ['price' => 10],
+            ['price' => 5],
         ], $this->testModel->schemaless_attributes->toArray());
     }
 

--- a/tests/HasSchemalessAttributesTest.php
+++ b/tests/HasSchemalessAttributesTest.php
@@ -328,6 +328,89 @@ class HasSchemalessAttributesTest extends TestCase
         $this->assertEquals('subVal1', $this->testModel->schemaless_attributes->arr['subKey1']);
     }
 
+    /** @test */
+    public function it_can_call_collection_method_pop()
+    {
+        $this->testModel->schemaless_attributes->set([
+            'foo' => 'bar',
+            'baz' => 'buzz',
+            'arr' => [
+                'subKey1' => 'subVal1',
+                'subKey2' => 'subVal2',
+            ],
+        ]);
+
+        $item = $this->testModel->schemaless_attributes->pop();
+
+        $this->assertEquals([
+            'subKey1' => 'subVal1',
+            'subKey2' => 'subVal2',
+        ], $item);
+        $this->assertEquals([
+            'foo' => 'bar',
+            'baz' => 'buzz',
+        ], $this->testModel->schemaless_attributes->toArray());
+    }
+
+    /** @test */
+    public function it_can_call_collection_method_sum()
+    {
+        $this->testModel->schemaless_attributes->set([
+            [ 'price' => 10 ],
+            [ 'price' => 5 ],
+        ]);
+
+        $this->assertEquals(15, $this->testModel->schemaless_attributes->sum('price'));
+        $this->assertEquals([
+            [ 'price' => 10 ],
+            [ 'price' => 5 ],
+        ], $this->testModel->schemaless_attributes->toArray());
+    }
+
+    /** @test */
+    public function it_can_call_collection_method_slice()
+    {
+        $this->testModel->schemaless_attributes->set([
+            'foo' => 'bar',
+            'baz' => 'buzz',
+            'lorem' => 'ipsum',
+            'dolor' => 'amet',
+        ]);
+
+        $this->assertEquals([
+            'baz' => 'buzz',
+            'lorem' => 'ipsum',
+        ], $this->testModel->schemaless_attributes->slice(1, 2)->toArray());
+        $this->assertEquals([
+            'foo' => 'bar',
+            'baz' => 'buzz',
+            'lorem' => 'ipsum',
+            'dolor' => 'amet',
+        ], $this->testModel->schemaless_attributes->toArray());
+    }
+
+    /** @test */
+    public function it_can_call_collection_method_only()
+    {
+        $this->testModel->schemaless_attributes->set([
+            'foo' => 'bar',
+            'baz' => 'buzz',
+            'lorem' => 'ipsum',
+            'dolor' => 'amet',
+        ]);
+
+        $this->assertEquals([
+            'baz' => 'buzz',
+            'dolor' => 'amet',
+        ], $this->testModel->schemaless_attributes->only('baz', 'dolor')->toArray());
+        $this->assertEquals([
+            'foo' => 'bar',
+            'baz' => 'buzz',
+            'lorem' => 'ipsum',
+            'dolor' => 'amet',
+        ], $this->testModel->schemaless_attributes->toArray());
+    }
+
     protected function assertContainsModels(array $expectedModels, Collection $actualModels)
     {
         $assertionFailedMessage = 'Expected '.count($expectedModels).' models. Got '.$actualModels->count().' models';


### PR DESCRIPTION
This changes the `SchemalessAttributes` to offer all methods available on a collection. It forwards all calls and customizes some of them to handle dot.notation and be not BC.

It shouldn't be breaking because all interfaces are still implemented and all unittests still pass.
