### PR TITLE
Remove typehint from getRawSchemalessAttributes

### DIFF
--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -180,7 +180,7 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
         return $this->collection->getIterator();
     }
 
-    protected function getRawSchemalessAttributes(): array
+    protected function getRawSchemalessAttributes()
     {
         return $this->model->fromJson($this->model->getAttributes()[$this->sourceAttributeName] ?? '{}');
     }


### PR DESCRIPTION
Resolves getRawSchemalessAttributes() must be of the type array, string returned. 

When no extra_attribute is returned, the getRawSchemalessAttributes function returns an empty string, not an array. Return type is therefore mixed not an array.