### PR TITLE
Fixes Return value of getRawSchemalessAttributes() must be of the type array, string returned

### DIFF
--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -183,6 +183,7 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
     protected function getRawSchemalessAttributes(): ?array
     {
         $attributes = $this->model->getAttributes()[$this->sourceAttributeName] ?? "{}";
+
         return (is_null($attributes) || $attributes == "[null]" || $attributes = "") ? array() : $this->model->fromJson($attributes);
     }
 

--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -180,9 +180,10 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
         return $this->collection->getIterator();
     }
 
-    protected function getRawSchemalessAttributes(): array
+    protected function getRawSchemalessAttributes(): ?array
     {
-        return $this->model->fromJson($this->model->getAttributes()[$this->sourceAttributeName] ?? '{}');
+        $attributes = $this->model->getAttributes()[$this->sourceAttributeName] ?? "{}";
+        return (is_null($attributes) || $attributes == "[null]" || $attributes = "") ? array() : $this->model->fromJson($attributes);
     }
 
     protected function override(iterable $collection)


### PR DESCRIPTION
Spatie\SchemalessAttributes\SchemalessAttributs::getRawSchemalessAttributes() must be of the type array, string returned when used with Postgres JSON data types.

This changes the return casting to a nullable array which is returned if the object from the database does is null, contains the word null or an empty string. This should cover all scenarios from both postgres and mysql.