### PR TITLE
 getRawSchemalessAttributes() must be of the type array, string returned

### DIFF
--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -182,9 +182,9 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
 
     protected function getRawSchemalessAttributes(): ?array
     {
-        $attributes = $this->model->getAttributes()[$this->sourceAttributeName] ?? "{}";
+        $attributes = $this->model->getAttributes()[$this->sourceAttributeName] ?? '{}';
 
-        return ($attributes =="\"\"" ? [] : $this->model->fromJson($attributes));
+        return ($attributes =='""' ? [] : $this->model->fromJson($attributes));
     }
 
     protected function override(iterable $collection)

--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -183,6 +183,7 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
     protected function getRawSchemalessAttributes(): ?array
     {
         $attributes = $this->model->getAttributes()[$this->sourceAttributeName] ?? "{}";
+
         return (is_null($attributes) || $attributes == "[null]" || $attributes = "") ? array() : $this->model->fromJson($attributes);
     }
 

--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -180,9 +180,10 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
         return $this->collection->getIterator();
     }
 
-    protected function getRawSchemalessAttributes(): array
+    protected function getRawSchemalessAttributes(): ?array
     {
-        return $this->model->fromJson($this->model->getAttributes()[$this->sourceAttributeName] ?? '{}');
+        $attributes = $this->model->getAttributes()[$this->sourceAttributeName] ?? "{}";
+        return (is_null($attributes) || $attributes == "[null]" || $attributes = "") ? array() : $this->model->fromJson($attributes);
     }
 
     protected function override(iterable $collection)

--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -184,7 +184,7 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
     {
         $attributes = $this->model->getAttributes()[$this->sourceAttributeName] ?? "{}";
 
-        return (is_null($attributes) || $attributes == "[null]" || $attributes = "") ? array() : $this->model->fromJson($attributes);
+        return ($attributes =="\"\"" ? [] : $this->model->fromJson($attributes));
     }
 
     protected function override(iterable $collection)


### PR DESCRIPTION
When using laravel-schemaless-attributes with postgresql database the returned object when empty is a string not an array.