### PR TITLE
getRawSchemalessAttributes() must be of the type array

### DIFF
--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -184,7 +184,7 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
     {
         $attributes = $this->model->getAttributes()[$this->sourceAttributeName] ?? '{}';
 
-        return ($attributes =='""' ? [] : $this->model->fromJson($attributes));
+        return $attributes =='""' ? [] : $this->model->fromJson($attributes);
     }
 
     protected function override(iterable $collection)


### PR DESCRIPTION
Fixes issue #45 getRawSchemalessAttributes() must be of the type array, string returned on Postgresql which returns a string object rather than an array when null stored in SchemalessAttributes.

Includes StyleCI fixes.