### PR TITLE
Fix the wrong trait initializer in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ use Spatie\SchemalessAttributes\Casts\SchemalessAttributes;
 
 trait HasSchemalessAttributes
 {
-    public function initializeHasSchemalessAttributesTrait()
+    public function initializeHasSchemalessAttributes()
     {
         $this->casts['extra_attributes'] = SchemalessAttributes::class;
     }

--- a/tests/Concerns/HasSchemalessAttributes.php
+++ b/tests/Concerns/HasSchemalessAttributes.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\SchemalessAttributes\Tests\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\SchemalessAttributes\Casts\SchemalessAttributes;
+
+/** @mixin \Illuminate\Database\Eloquent\Model */
+trait HasSchemalessAttributes
+{
+    public function initializeHasSchemalessAttributes()
+    {
+        $this->casts['schemaless_attributes'] = SchemalessAttributes::class;
+    }
+
+    public function scopeWithExtraAttributes(): Builder
+    {
+        return $this->schemaless_attributes->modelScope();
+    }
+}

--- a/tests/HasSchemalessAttributesTest.php
+++ b/tests/HasSchemalessAttributesTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\SchemalessAttributes\Tests;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
 class HasSchemalessAttributesTest extends TestCase
@@ -9,11 +10,16 @@ class HasSchemalessAttributesTest extends TestCase
     /** @var \Spatie\SchemalessAttributes\Tests\TestModel */
     protected $testModel;
 
+    /** @var \Spatie\SchemalessAttributes\Tests\TestModel */
+    protected $testModelUsedTrait;
+
     public function setUp(): void
     {
         parent::setUp();
 
         $this->testModel = TestModel::create();
+
+        $this->testModelUsedTrait = new TestModel();
     }
 
     /** @test */
@@ -429,6 +435,14 @@ class HasSchemalessAttributesTest extends TestCase
             'lorem' => 'ipsum',
             'dolor' => 'amet',
         ], $this->testModel->schemaless_attributes->toArray());
+    }
+
+    /** @test */
+    public function an_schemaless_attribute_can_be_set_if_the_has_schemaless_atrributes_trait_is_used(): void
+    {
+        $this->testModelUsedTrait->schemaless_attributes->name = 'value';
+
+        $this->assertEquals('value', $this->testModelUsedTrait->schemaless_attributes->name);
     }
 
     protected function assertContainsModels(array $expectedModels, Collection $actualModels)

--- a/tests/TestModelUsedHasSchemalessAttributesTrait.php
+++ b/tests/TestModelUsedHasSchemalessAttributesTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\SchemalessAttributes\Tests;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\SchemalessAttributes\Tests\Concerns\HasSchemalessAttributes;
+
+class TestModelUsedHasSchemalessAttributesTrait extends Model
+{
+    use HasSchemalessAttributes;
+
+    public $timestamps = false;
+
+    public $guarded = [];
+}


### PR DESCRIPTION
This PR will fix a little typo in your [README.md](https://github.com/spatie/laravel-schemaless-attributes/blame/main/README.md#L153). You use a suffix: `Trait` for the `initializeHasSchemalessAttributes()` - method this is wrong and will be ignored by Laravel Models. 

I also added a small test to check if the trait actually works.