### PR TITLE
Scope retrieving models with operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ If you only want to search on a single custom attribute, you can use the modelSc
 $yourModel->withExtraAttributes('name', 'value')->get();
 ```
 
+Also, if you only want to search on a single custom attribute with a custom operator, you can use the modelScope like this
+
+```php
+// returns all models that have a schemaless attribute `name` starting with `value`
+$yourModel->withExtraAttributes('name', 'LIKE', 'value%')->get();
+```
+
 If you only want to search on a nested custom attribute, you can use the modelScope like this
 
 ```php

--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -111,13 +111,18 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
             [$builder, $schemalessAttributes] = $arguments;
         }
 
-        if (count($arguments) >= 3) {
+        if (count($arguments) === 3) {
             [$builder, $name, $value] = $arguments;
             $schemalessAttributes = [$name => $value];
         }
 
+        if (count($arguments) >= 4) {
+            [$builder, $name, $operator, $value] = $arguments;
+            $schemalessAttributes = [$name => $value];
+        }
+
         foreach ($schemalessAttributes as $name => $value) {
-            $builder->where("{$this->sourceAttributeName}->{$name}", $value);
+            $builder->where("{$this->sourceAttributeName}->{$name}", $operator ?? '=', $value);
         }
 
         return $builder;

--- a/tests/HasSchemalessAttributesTest.php
+++ b/tests/HasSchemalessAttributesTest.php
@@ -274,16 +274,25 @@ class HasSchemalessAttributesTest extends TestCase
         $model1 = TestModel::create(['schemaless_attributes' => [
             'name' => 'value',
             'name2' => 'value2',
+            'arr' => [
+                'subKey1' => 'subVal1'
+            ]
         ]]);
 
         $model2 = TestModel::create(['schemaless_attributes' => [
             'name' => 'value',
             'name2' => 'value2',
+            'arr' => [
+                'subKey1' => 'subVal1'
+            ]
         ]]);
 
         $model3 = TestModel::create(['schemaless_attributes' => [
             'name' => 'value',
             'name2' => 'value3',
+            'arr' => [
+                'subKey1' => 'subVal2'
+            ]
         ]]);
 
         $this->assertContainsModels([
@@ -306,7 +315,16 @@ class HasSchemalessAttributesTest extends TestCase
         ], TestModel::withSchemalessAttributes('name', 'value')->get());
 
         $this->assertContainsModels([
-        ], TestModel::withSchemalessAttributes('name', 'non-existing-value')->get());
+            $model1, $model2,
+        ], TestModel::withSchemalessAttributes('name2', '!=', 'value3')->get());
+
+        $this->assertContainsModels([
+            $model3,
+        ], TestModel::withSchemalessAttributes('arr->subKey1', 'subVal2')->get());
+
+        $this->assertContainsModels([
+            $model1, $model2,
+        ], TestModel::withSchemalessAttributes('arr->subKey1', '!=', 'subVal2')->get());
 
         $this->assertContainsModels([
         ], TestModel::withSchemalessAttributes('name', 'non-existing-value')->get());


### PR DESCRIPTION
If you only want to search on a single custom attribute with a custom operator, you can use the modelScope like this

```php
// returns all models that have a schemaless attribute `name` starting with `value`
$yourModel->withExtraAttributes('name', 'LIKE', 'value%')->get();
// returns all models that have a schemaless attribute `name` different that `value`
$yourModel->withExtraAttributes('name', '!=', 'value')->get();
// returns all models that have a schemaless attribute `number` greater than `10`
$yourModel->withExtraAttributes('number', '>', 10)->get();

```
