### PR TITLE
Avoid exceptions on invalid values, uses empty array instead

### DIFF
--- a/src/Casts/SchemalessAttributes.php
+++ b/src/Casts/SchemalessAttributes.php
@@ -32,19 +32,31 @@ class SchemalessAttributes implements CastsAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
-        if ($this->isJson($value)) {
+        if ($this->isJsonArray($value)) {
             return $value;
         }
 
-        return json_encode($value);
+        $json = json_encode($value);
+
+        if (! is_array(json_decode($json, true))) {
+            return null;
+        }
+
+        return $json;
     }
 
-    protected function isJson($value): bool
+    protected function isJsonArray($value): bool
     {
         if (! is_string($value)) {
             return false;
         }
 
-        return  $value === json_encode(json_decode($value));
+        $array = json_decode($value, true);
+
+        if (! is_array($array)) {
+            return false;
+        }
+
+        return $value === json_encode($array);
     }
 }

--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -177,7 +177,9 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
     {
         $attributes = $this->model->getAttributes()[$this->sourceAttributeName] ?? '{}';
 
-        return $attributes === '""' ? [] : $this->model->fromJson($attributes);
+        $array = $this->model->fromJson($attributes);
+
+        return is_array($array) ? $array : [];
     }
 
     protected function override(iterable $collection): static

--- a/tests/HasSchemalessAttributesTest.php
+++ b/tests/HasSchemalessAttributesTest.php
@@ -50,6 +50,31 @@ class HasSchemalessAttributesTest extends TestCase
     }
 
     /** @test */
+    public function an_schemaless_attribute_uses_fallback_empty_array_on_non_valid_values()
+    {
+        $this->testModel->schemaless_attributes = 'string';
+        $this->assertEquals([], $this->testModel->schemaless_attributes->all());
+
+        $this->testModel->schemaless_attributes = '""'; // not array json
+        $this->assertEquals([], $this->testModel->schemaless_attributes->all());
+
+        $this->testModel->schemaless_attributes = "{'name':'value'}"; // invalid json format
+        $this->assertEquals([], $this->testModel->schemaless_attributes->all());
+
+        $this->testModel->schemaless_attributes = null;
+        $this->assertEquals([], $this->testModel->schemaless_attributes->all());
+
+        $this->testModel->schemaless_attributes = false;
+        $this->assertEquals([], $this->testModel->schemaless_attributes->all());
+
+        $this->testModel->schemaless_attributes = 1;
+        $this->assertEquals([], $this->testModel->schemaless_attributes->all());
+
+        $this->testModel->schemaless_attributes = 0.1;
+        $this->assertEquals([], $this->testModel->schemaless_attributes->all());
+    }
+
+    /** @test */
     public function it_can_determine_if_it_has_a_schemaless_attribute()
     {
         $this->assertFalse($this->testModel->schemaless_attributes->has('name'));
@@ -264,6 +289,31 @@ class HasSchemalessAttributesTest extends TestCase
         $testModel = TestModel::create(['schemaless_attributes' => json_encode($array)]);
 
         $this->assertEquals($array, $testModel->schemaless_attributes->all());
+    }
+
+    /** @test */
+    public function it_can_and_save_schemaless_attributes_as_null_when_non_valid_values()
+    {
+        $testModel = TestModel::create(['schemaless_attributes' => 'string']);
+        $this->assertEquals(null, $testModel->getAttributes()['schemaless_attributes']);
+
+        $testModel = TestModel::create(['schemaless_attributes' => '""']); // not array json
+        $this->assertEquals(null, $testModel->getAttributes()['schemaless_attributes']);
+
+        $testModel = TestModel::create(['schemaless_attributes' => "{'name':'value'}"]); // invalid json format
+        $this->assertEquals(null, $testModel->getAttributes()['schemaless_attributes']);
+
+        $testModel = TestModel::create(['schemaless_attributes' => null]);
+        $this->assertEquals(null, $testModel->getAttributes()['schemaless_attributes']);
+
+        $testModel = TestModel::create(['schemaless_attributes' => false]);
+        $this->assertEquals(null, $testModel->getAttributes()['schemaless_attributes']);
+
+        $testModel = TestModel::create(['schemaless_attributes' => 1]);
+        $this->assertEquals(null, $testModel->getAttributes()['schemaless_attributes']);
+
+        $testModel = TestModel::create(['schemaless_attributes' => 0.1]);
+        $this->assertEquals(null, $testModel->getAttributes()['schemaless_attributes']);
     }
 
     /** @test */


### PR DESCRIPTION
`$attributes === '""' ? [] :` does not cover all possibilities, for example `'" "'`,`'"&nbsp;"'`
array must be the only acepted type
https://github.com/spatie/laravel-schemaless-attributes/blob/0e8b8e36b1589f1d0a0d2fea0f1fa6c61aff97ba/src/SchemalessAttributes.php#L180