### PR TITLE
Added optional "columnType" parameter to macro.

### DIFF
--- a/src/SchemalessAttributesServiceProvider.php
+++ b/src/SchemalessAttributesServiceProvider.php
@@ -16,7 +16,12 @@ class SchemalessAttributesServiceProvider extends PackageServiceProvider
 
     public function registeringPackage(): void
     {
-        Blueprint::macro('schemalessAttributes', function (string $columnName = 'schemaless_attributes') {
+        Blueprint::macro('schemalessAttributes', function (string $columnName = 'schemaless_attributes', string $columnType = 'json') {
+            
+            if ($columnType === 'jsonb') {
+                return $this->jsonb($columnName)->nullable();                
+            }
+            
             return $this->json($columnName)->nullable();
         });
     }


### PR DESCRIPTION
This PR enables the support of JSONB columns by an additional parameter in `schemalessAttributes` macro.