### PR TITLE
Model scope builds query with orWhere

### DIFF
--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -129,6 +129,36 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
         return $builder;
     }
 
+    public function modelScopeOrWhere(): Builder
+    {
+        $arguments = debug_backtrace()[1]['args'];
+
+        if (count($arguments) === 1) {
+            [$builder] = $arguments;
+            $schemalessAttributes = [];
+        }
+
+        if (count($arguments) === 2) {
+            [$builder, $schemalessAttributes] = $arguments;
+        }
+
+        if (count($arguments) === 3) {
+            [$builder, $name, $value] = $arguments;
+            $schemalessAttributes = [$name => $value];
+        }
+
+        if (count($arguments) >= 4) {
+            [$builder, $name, $operator, $value] = $arguments;
+            $schemalessAttributes = [$name => $value];
+        }
+
+        foreach ($schemalessAttributes as $name => $value) {
+            $builder->orWhere("{$this->sourceAttributeName}->{$name}", $operator ?? '=', $value);
+        }
+
+        return $builder;
+    }
+
     public function offsetGet($offset): mixed
     {
         return $this->get($offset);

--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -129,7 +129,12 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
         return $builder;
     }
 
-    public function modelScopeOrWhere(): Builder
+    /**
+     * Adds orWhere to the Query Builder instance to enable larger scopes for searching
+     *
+     * @return Builder
+     */
+    public function modelScopeByOrWhere(): Builder
     {
         $arguments = debug_backtrace()[1]['args'];
 

--- a/tests/Concerns/HasSchemalessAttributes.php
+++ b/tests/Concerns/HasSchemalessAttributes.php
@@ -17,4 +17,9 @@ trait HasSchemalessAttributes
     {
         return $this->schemaless_attributes->modelScope();
     }
+
+    public function scopeWithOrWhereExtraAttributes(): Builder
+    {
+        return $this->schemaless_attributes->modelScopeByOrWhere();
+    }
 }

--- a/tests/TestModel.php
+++ b/tests/TestModel.php
@@ -20,4 +20,9 @@ class TestModel extends Model
     {
         return $this->schemaless_attributes->modelScope();
     }
+
+    public function scopeWithOrWhereExtraAttributes(): Builder
+    {
+        return $this->schemaless_attributes->modelScopeByOrWhere();
+    }
 }


### PR DESCRIPTION
As described in https://github.com/spatie/laravel-schemaless-attributes/discussions/104 it would enhance the features of this package since `modelScope` adds a `where()` . Useful particularly when you have to search for a text (**value**) in multiple columns (**keys**). 

Open to any suggestions/discussion